### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -20,7 +20,7 @@ jobs:
 #        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.1.0
         with:
           java-version: 11
           distribution: adopt
@@ -35,12 +35,12 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.0.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.1.0
+        uses: fossas/fossa-action@v1.1.1
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-lib-release.yml
+++ b/.github/workflows/gradle-lib-release.yml
@@ -43,7 +43,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.1.0
         with:
           java-version: 11
           distribution: adopt

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -20,7 +20,7 @@ jobs:
 #        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.1.0
         with:
           java-version: 11
           distribution: adopt
@@ -35,12 +35,12 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.0.0
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true
 
       - name: FOSSA
-        uses: fossas/fossa-action@v1.1.0
+        uses: fossas/fossa-action@v1.1.1
         with:
           api-key: ${{ secrets.fossa-api-key }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -37,7 +37,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.1.0
         with:
           java-version: 11
           distribution: adopt

--- a/.github/workflows/workflow-cancel.yml
+++ b/.github/workflows/workflow-cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           workflow_id: 'build.yml,deploy-dev.yml,deploy-prod.yml,release.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v3.0.0](https://github.com/codecov/codecov-action/releases/tag/v3.0.0) on 2022-04-05T14:17:42Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release [0.9.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.9.1) on 2021-07-29T20:59:53Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.1.0](https://github.com/actions/setup-java/releases/tag/v3.1.0) on 2022-04-01T09:07:18Z
* **[fossas/fossa-action](https://github.com/fossas/fossa-action)** published a new release [v1.1.1](https://github.com/fossas/fossa-action/releases/tag/v1.1.1) on 2022-04-08T21:33:14Z
