### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v3.2.0
+        uses: actions/setup-node@v3.3.0
         with:
           node-version: 12
 

--- a/.github/workflows/gradle-azure-app-service-deploy.yml
+++ b/.github/workflows/gradle-azure-app-service-deploy.yml
@@ -59,7 +59,7 @@ jobs:
           app-settings-json: ${{ secrets.azure-app-settings }}
 
       - name: Deploy
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v2.2.3
         with:
           app-name: ${{ secrets.azure-app-name }}
           publish-profile: ${{ secrets.azure-app-profile }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[azure/webapps-deploy](https://github.com/azure/webapps-deploy)** published a new release [v2.2.3](https://github.com/Azure/webapps-deploy/releases/tag/v2.2.3) on 2021-06-29T04:37:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.3.0](https://github.com/actions/setup-node/releases/tag/v3.3.0) on 2022-06-06T12:52:11Z
