### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/workflow-cancel.yml
+++ b/.github/workflows/workflow-cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           workflow_id: 'build.yml,deploy-dev.yml,deploy-prod.yml,release.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-clear-packages.yml
+++ b/.github/workflows/workflow-clear-packages.yml
@@ -17,7 +17,7 @@ jobs:
           name=$(awk '/rootProject.name/{print $NF; exit}' settings.gradle.kts | sed s/\'//g | sed s/\"//g)
           echo "PACKAGE_NAME=${group}.${name}" >> $GITHUB_ENV
 
-      - uses: actions/delete-package-versions@v3
+      - uses: actions/delete-package-versions@v3.0.0
         with:
           package-name: ${{ env.PACKAGE_NAME }}
           min-versions-to-keep: 2


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/delete-package-versions](https://github.com/actions/delete-package-versions)** published a new release [v3.0.0](https://github.com/actions/delete-package-versions/releases/tag/v3.0.0) on 2022-03-02T08:00:00Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release [0.10.0](https://github.com/styfle/cancel-workflow-action/releases/tag/0.10.0) on 2022-06-27T03:02:39Z
