### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: 12
 

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -47,7 +47,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -51,7 +51,7 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -103,7 +103,7 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-oss-release.yml
+++ b/.github/workflows/gradle-oss-release.yml
@@ -59,7 +59,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}
@@ -52,7 +52,7 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -53,7 +53,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.5.0
+        uses: actions/setup-java@v3.5.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/workflow-cancel.yml
+++ b/.github/workflows/workflow-cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           workflow_id: 'build.yml,deploy-dev.yml,deploy-prod.yml,release.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.5.1](https://github.com/actions/setup-node/releases/tag/v3.5.1) on 2022-10-13T12:19:17Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release [v3.5.1](https://github.com/actions/setup-java/releases/tag/v3.5.1) on 2022-09-26T14:07:25Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1) on 2022-09-19T15:25:54Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release [0.11.0](https://github.com/styfle/cancel-workflow-action/releases/tag/0.11.0) on 2022-10-12T13:00:03Z
