### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/bash-bats-build.yml
+++ b/.github/workflows/bash-bats-build.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 12
 

--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.5
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.5
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -47,7 +47,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.5
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.5
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-oss-release.yml
+++ b/.github/workflows/gradle-oss-release.yml
@@ -59,7 +59,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.5
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -53,7 +53,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/workflow-clear-packages.yml
+++ b/.github/workflows/workflow-clear-packages.yml
@@ -17,7 +17,7 @@ jobs:
           name=$(awk '/rootProject.name/{print $NF; exit}' settings.gradle.kts | sed s/\'//g | sed s/\"//g)
           echo "PACKAGE_NAME=${group}.${name}" >> $GITHUB_ENV
 
-      - uses: actions/delete-package-versions@v3.0.1
+      - uses: actions/delete-package-versions@v4.0.0
         with:
           package-name: ${{ env.PACKAGE_NAME }}
           min-versions-to-keep: 2


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.6.0](https://github.com/actions/setup-node/releases/tag/v3.6.0)** on 2023-01-05T14:09:37Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.9.0](https://github.com/actions/setup-java/releases/tag/v3.9.0)** on 2022-12-14T13:33:59Z
* **[actions/delete-package-versions](https://github.com/actions/delete-package-versions)** published a new release **[v4.0.0](https://github.com/actions/delete-package-versions/releases/tag/v4.0.0)** on 2023-01-05T11:55:28Z
