### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/workflow-update-actions.yml
+++ b/.github/workflows/workflow-update-actions.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Update Workflow Action Versions
-        uses: saadmk11/github-actions-version-updater@v0.7.3
+        uses: saadmk11/github-actions-version-updater@v0.7.4
         with:
           committer_username: ${{ secrets.GIT_USER }}
           committer_email: ${{ secrets.GIT_EMAIL }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
