### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.6
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -73,7 +73,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.6
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -47,7 +47,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.6
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.6
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-oss-release.yml
+++ b/.github/workflows/gradle-oss-release.yml
@@ -59,7 +59,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -37,7 +37,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.0.6
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -53,7 +53,7 @@ jobs:
           GIT_USER: ${{ secrets.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.10.0
+        uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.11.0](https://github.com/actions/setup-java/releases/tag/v3.11.0)** on 2023-03-27T14:55:26Z
