### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -75,7 +75,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -48,7 +48,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -67,7 +67,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-oss-release.yml
+++ b/.github/workflows/gradle-oss-release.yml
@@ -61,7 +61,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -55,7 +55,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.13.0](https://github.com/actions/setup-java/releases/tag/v3.13.0)** on 2023-09-20T12:22:38Z
