### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -75,7 +75,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-azure-app-service-deploy.yml
+++ b/.github/workflows/gradle-azure-app-service-deploy.yml
@@ -60,7 +60,7 @@ jobs:
           app-settings-json: ${{ secrets.azure-app-settings }}
 
       - name: Deploy
-        uses: azure/webapps-deploy@v2.2.11
+        uses: azure/webapps-deploy@v3.0.0
         with:
           app-name: ${{ secrets.azure-app-name }}
           publish-profile: ${{ secrets.azure-app-profile }}

--- a/.github/workflows/gradle-github-release.yml
+++ b/.github/workflows/gradle-github-release.yml
@@ -48,7 +48,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -67,7 +67,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-oss-release.yml
+++ b/.github/workflows/gradle-oss-release.yml
@@ -61,7 +61,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1.1.0
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/gradle-plugin-release.yml
+++ b/.github/workflows/gradle-plugin-release.yml
@@ -55,7 +55,7 @@ jobs:
           GIT_USER: ${{ inputs.git-email }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: ${{ inputs.java-version }}
           distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/workflow-cancel.yml
+++ b/.github/workflows/workflow-cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@0.12.0
         with:
           workflow_id: 'build.yml,deploy-dev.yml,deploy-prod.yml,release.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[azure/webapps-deploy](https://github.com/azure/webapps-deploy)** published a new release **[v3.0.0](https://github.com/Azure/webapps-deploy/releases/tag/v3.0.0)** on 2023-10-11T12:51:19Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release **[0.12.0](https://github.com/styfle/cancel-workflow-action/releases/tag/0.12.0)** on 2023-10-03T15:32:10Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v3.13.0](https://github.com/actions/setup-java/releases/tag/v3.13.0)** on 2023-09-20T12:22:38Z
