### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gradle-app-build.yml
+++ b/.github/workflows/gradle-app-build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-app-postgres-build.yml
+++ b/.github/workflows/gradle-app-postgres-build.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Coverage
         if: ${{ inputs.run-coverage == 'true' }}
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-azure-app-service-deploy.yml
+++ b/.github/workflows/gradle-azure-app-service-deploy.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Azure Login
-        uses: azure/login@v1.5.1
+        uses: azure/login@v1.6.1
         with:
           creds: ${{ secrets.azure-app-credentials }}
 

--- a/.github/workflows/gradle-lib-build.yml
+++ b/.github/workflows/gradle-lib-build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-lib-postgres-build.yml
+++ b/.github/workflows/gradle-lib-postgres-build.yml
@@ -111,7 +111,7 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/gradle-plugin-build.yml
+++ b/.github/workflows/gradle-plugin-build.yml
@@ -51,7 +51,7 @@ jobs:
         uses: fabiocapasso93/gha-kotlin-linter@v1.1
 
       - name: Coverage
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3.1.5
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           verbose: true

--- a/.github/workflows/workflow-cancel.yml
+++ b/.github/workflows/workflow-cancel.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Cancel
-        uses: styfle/cancel-workflow-action@0.12.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           workflow_id: 'build.yml,deploy-dev.yml,deploy-prod.yml,release.yml'
           access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-clear-packages.yml
+++ b/.github/workflows/workflow-clear-packages.yml
@@ -17,7 +17,7 @@ jobs:
           name=$(awk '/rootProject.name/{print $NF; exit}' settings.gradle.kts | sed s/\'//g | sed s/\"//g)
           echo "PACKAGE_NAME=${group}.${name}" >> $GITHUB_ENV
 
-      - uses: actions/delete-package-versions@v4.1.1
+      - uses: actions/delete-package-versions@v5.0.0
         with:
           package-name: ${{ env.PACKAGE_NAME }}
           package-type: maven


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.5](https://github.com/codecov/codecov-action/releases/tag/v3.1.5)** on 2024-01-25T18:48:29Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release **[0.12.1](https://github.com/styfle/cancel-workflow-action/releases/tag/0.12.1)** on 2024-01-25T16:36:58Z
* **[azure/login](https://github.com/azure/login)** published a new release **[v1.6.1](https://github.com/Azure/login/releases/tag/v1.6.1)** on 2024-01-23T02:20:59Z
* **[actions/delete-package-versions](https://github.com/actions/delete-package-versions)** published a new release **[v5.0.0](https://github.com/actions/delete-package-versions/releases/tag/v5.0.0)** on 2024-01-16T13:50:21Z
